### PR TITLE
fix garbled strings and respect device locale when mapping string resources

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -6,7 +6,7 @@
     android:versionName="1.6" >
 
     <uses-sdk 
-        android:minSdkVersion="10" 
+        android:minSdkVersion="10"
         android:targetSdkVersion="17" />
 		
    	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>

--- a/src/com/iwisdomsky/resflux/AaptManager.java
+++ b/src/com/iwisdomsky/resflux/AaptManager.java
@@ -4,10 +4,8 @@ import android.content.*;
 import java.io.*;
 
 public abstract class AaptManager 
-{	
-	
-	
-	private static DataInputStream getDump(Context context, String apk_path,String what){
+{
+	private static BufferedReader getDump(Context context, String apk_path,String what){
 		java.lang.Process proc = null;
 		try
 		{
@@ -15,11 +13,16 @@ public abstract class AaptManager
 		}
 		catch (IOException e)
 		{}
-		return new DataInputStream(proc.getInputStream());		
+		try {
+			return new BufferedReader(new InputStreamReader(proc.getInputStream(), "UTF-8"));
+		} catch (UnsupportedEncodingException e)
+		{}
+
+		return null;
 	}
 	
 
-	public static DataInputStream getDumpResourcesStream(Context context, String apk_path){
+	public static BufferedReader getDumpResourcesStream(Context context, String apk_path){
 		return getDump(context, apk_path, "resources");
 	}
 

--- a/src/com/iwisdomsky/resflux/AndroidPackage.java
+++ b/src/com/iwisdomsky/resflux/AndroidPackage.java
@@ -36,91 +36,107 @@ public class AndroidPackage
 	
 	
 	public AndroidPackage.Resources getResources(){
-		DataInputStream in = AaptManager.getDumpResourcesStream(mContext, this.SOURCE);
+		BufferedReader in = AaptManager.getDumpResourcesStream(mContext, this.SOURCE);
 		TreeMap<String,String> drawables = new TreeMap<String,String>()/*getResourcesOfType("drawable")*/;
 		TreeMap<String,String> strings =  new TreeMap<String,String>()/*/*getResourcesOfType("string")*/;
 		TreeMap<String,String> colors =  new TreeMap<String,String>()/*/*getResourcesOfType("color")*/;
 		TreeMap<String,String> bools =  new TreeMap<String,String>()/*/*getResourcesOfType("bool")*/;
 		TreeMap<String,String> integers =  new TreeMap<String,String>()/*/*getResourcesOfType("integer")*/;
+		TreeMap<String,String> locale_strings = new TreeMap<String,String>();
 				
-		String  line,
-				res_pattern ="^resource.+:(.+)/([\\w\\d]+):.*$",
-			    val_pattern = "^\\([^\\s]+\\)\\s[\\\"]?([^\\\"]+)[\\\"]?$";
+		String line;
+		String curr_conf = "";
+
+		String res_pattern ="^resource.+:(.+)/([\\w\\d]+):.*$";
+		String val_pattern = "^\\([^\\s]+\\)\\s[\\\"]?([^\\\"]+)[\\\"]?$";
+		String conf_pattern = "^config\\s([\\w\\d-]+):.*$";
+
 		try
 		{
-			while ( (line = in.readLine()) != null )
-			{
+			while ( (line = in.readLine()) != null ) {
 				line = line.trim();
-				if ( line.matches(res_pattern) ) {
-					String  i_val, // value
+
+				if (line.matches(conf_pattern)) {
+					curr_conf = line.replaceAll(conf_pattern, "$1");
+				}
+
+				if (line.matches(res_pattern)) {
+					String i_val, // value
 							i_res = line.replaceAll(res_pattern, "$2"), // reaource name
 							res_type = line.replaceAll(res_pattern, "$1"); // resource type
-							
+
 					line = in.readLine().trim();
-					if ( line.matches(val_pattern) ) 
-						i_val = line.replaceAll(val_pattern,"$1");
+					if (line.matches(val_pattern))
+						i_val = line.replaceAll(val_pattern, "$1");
 					else
 						i_val = "";
-												
-					try{
-					switch ( ResType.valueOf(res_type.toUpperCase()) ) {
-						
-						// for DRAWABLES
-						case DRAWABLE:
-							// block xml drawables as they are not supported yet
-							if ( i_val.endsWith("xml") )
-								continue;			
-							drawables.put(i_res,i_val);
-							break;
-							
-							
-						// for STRINGS	
-						case STRING:					
-							strings.put(i_res,i_val);						
-							break;
-							
-							
-						// for COLORS	
-						case COLOR:
-							// block xml colors as they are not supported yet
-							if ( !i_val.matches("^#([a-fA-F\\d]{6}|[a-fA-F\\d]{8})$") )
+
+					try {
+						switch (ResType.valueOf(res_type.toUpperCase())) {
+
+							// for DRAWABLES
+							case DRAWABLE:
+								// block xml drawables as they are not supported yet
+								if (i_val.endsWith("xml"))
+									continue;
+								drawables.put(i_res, i_val);
+								break;
+
+
+							// for STRINGS
+							case STRING:
+								if (curr_conf.equals(Locale.getDefault().getLanguage()) || curr_conf.equals(Locale.getDefault().getLanguage() + "-" + Locale.getDefault().getVariant())) {
+									locale_strings.put(i_res, i_val);
+								}
+								strings.put(i_res, i_val);
+								break;
+
+
+							// for COLORS
+							case COLOR:
+								// block xml colors as they are not supported yet
+								if (!i_val.matches("^#([a-fA-F\\d]{6}|[a-fA-F\\d]{8})$"))
+									continue;
+								colors.put(i_res, i_val);
+								break;
+
+
+							// for BOOLEANS
+							case BOOL:
+								// convert boolean hex value into true/false where #fffffff = true and #00000000 = false
+								if (i_val.matches("^#[f]+$"))
+									i_val = "true";
+								else if (i_val.matches("^#[0]+$"))
+									i_val = "false";
+								else
+									continue;
+								bools.put(i_res, i_val);
+								break;
+
+
+							// for INTEGERS
+							case INTEGER:
+								// since integer values are in its hex form, let's convert it into dec
+								if (i_val.matches("^#[a-fA-F\\d]+$"))
+									i_val = String.valueOf(Integer.parseInt(i_val.replaceAll("^#([a-fA-F\\d]+)$", "$1"), 16));
+								else
+									continue;
+								integers.put(i_res, i_val);
+								break;
+
+
+							default:
 								continue;
-							colors.put(i_res,i_val);	
-							break;
-							
-							
-						// for BOOLEANS	
-						case BOOL:			
-							// convert boolean hex value into true/false where #fffffff = true and #00000000 = false
-							if ( i_val.matches("^#[f]+$") )
-								i_val = "true";
-							else if ( i_val.matches("^#[0]+$") )
-								i_val = "false";
-							else
-								continue;
-							bools.put(i_res,i_val);
-							break;
-							
-							
-						// for INTEGERS	
-						case INTEGER:				
-							// since integer values are in its hex form, let's convert it into dec
-							if ( i_val.matches("^#[a-fA-F\\d]+$") )
-								i_val = String.valueOf(Integer.parseInt(i_val.replaceAll("^#([a-fA-F\\d]+)$","$1"),16));
-							else
-								continue;
-							integers.put(i_res,i_val);
-							break;
-							
-							
-						default:continue;
+						}
+					} catch (IllegalArgumentException e) {
 					}
-					} catch (IllegalArgumentException e) {}
-					
-					
-								
+
+
 				}
 			}
+
+			// Override strings with localized strings
+			strings.putAll(locale_strings);
 		}
 		catch (IOException e)
 		{}

--- a/src/com/iwisdomsky/resflux/adapter/FileListAdapter.java
+++ b/src/com/iwisdomsky/resflux/adapter/FileListAdapter.java
@@ -8,7 +8,7 @@ import com.iwisdomsky.resflux.*;
 import java.io.*;
 import java.util.*;
 
-public class FileListAdapter extends ArrayAdapter<String>
+public class FileListAdapter extends ArrayAdapter<File>
  {
 
 	private final Activity mContext;

--- a/src/com/iwisdomsky/resflux/dialog/SetBooleanDialog.java
+++ b/src/com/iwisdomsky/resflux/dialog/SetBooleanDialog.java
@@ -103,8 +103,8 @@ public class SetBooleanDialog
 			mTButton.setBackgroundColor(0xff444444);
 			mFButton.setBackgroundColor(0x00000000);			
 		} else {
-			mTButton.setBackgroundResource(0x00000000);
-			mFButton.setBackgroundResource(0xff444444);						
+			mTButton.setBackgroundColor(0x00000000);
+			mFButton.setBackgroundColor(0xff444444);
 		}		
 		return this;
 	}
@@ -140,9 +140,6 @@ public class SetBooleanDialog
 		return this;		
 	}
 
-
-
-	@Override
 	public void show(){
 		mCPD = mDialog.create();
 		mCPD.show();

--- a/src/com/iwisdomsky/resflux/dialog/SetColorDialog.java
+++ b/src/com/iwisdomsky/resflux/dialog/SetColorDialog.java
@@ -174,10 +174,7 @@ public class SetColorDialog
 		mCButton.setVisibility(View.VISIBLE);
 		return this;		
 	}
-	
-	
-	
-	@Override
+
 	public void show(){
 		mCPD = mDialog.create();
 		mCPD.show();

--- a/src/com/iwisdomsky/resflux/dialog/SetDrawableDialog.java
+++ b/src/com/iwisdomsky/resflux/dialog/SetDrawableDialog.java
@@ -147,7 +147,6 @@ public class SetDrawableDialog
 			});
 	}
 
-	@Override
 	public void show(){
 		// create the dialog
 		mCPD = mDialog.create();

--- a/src/com/iwisdomsky/resflux/dialog/SetTextDialog.java
+++ b/src/com/iwisdomsky/resflux/dialog/SetTextDialog.java
@@ -122,10 +122,7 @@ public class SetTextDialog
 		mCButton.setVisibility(View.VISIBLE);
 		return this;		
 	}
-	
-	
-	
-	@Override
+
 	public void show(){
 		mCPD = mDialog.create();
 		mCPD.show();


### PR DESCRIPTION
This is a quick fix for [garbled strings](http://forum.xda-developers.com/showpost.php?p=53657187&postcount=54) problem mentioned several times in the XDA thread, as well as for the "wrong strings language" problem. Cached resources (for APKs which have already been mapped) are not affected and should be removed from `/data/data/com.iwisdomsky.resflux/cache` for the fix to take effect.
